### PR TITLE
[ODV-190] Security hardening: research-mode safe defaults & input val…

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ The Odelia Viewer is a cutting-edge medical imaging platform developed under the
 ## Installation and Setup 🚀
 This section guides you through the process of getting the Odelia Viewer up and running on your local machine using Docker.
 
+> **⚠️ Research / demo defaults — not for production.**
+> The default configuration is optimized for `docker compose up` on a
+> trusted local network and is **insecure by design** (LAN-bound ports,
+> hardcoded admin passwords, Keycloak `start-dev`, permissive Orthanc auth,
+> open CORS, debug API on). Before exposing any part of this stack beyond
+> a network you control, work through
+> [`docs/production-hardening.md`](docs/production-hardening.md) — and see
+> [`docs/restrict-to-localhost.md`](docs/restrict-to-localhost.md) if you
+> just need to keep colleagues off your VPS / cloud VM.
+
 ### Prerequisites
 1.  **Git:** Installed to clone the repository.
 2.  **Docker:** Installed on your computer (includes Docker Compose).

--- a/README.md
+++ b/README.md
@@ -11,14 +11,10 @@ The Odelia Viewer is a cutting-edge medical imaging platform developed under the
 This section guides you through the process of getting the Odelia Viewer up and running on your local machine using Docker.
 
 > **⚠️ Research / demo defaults — not for production.**
-> The default configuration is optimized for `docker compose up` on a
-> trusted local network and is **insecure by design** (LAN-bound ports,
-> hardcoded admin passwords, Keycloak `start-dev`, permissive Orthanc auth,
-> open CORS, debug API on). Before exposing any part of this stack beyond
-> a network you control, work through
-> [`docs/production-hardening.md`](docs/production-hardening.md) — and see
-> [`docs/restrict-to-localhost.md`](docs/restrict-to-localhost.md) if you
-> just need to keep colleagues off your VPS / cloud VM.
+> The default configuration is meant for local research and demos on a
+> trusted network. **Do not expose this stack to the public internet
+> as-is.** If you plan to host it beyond your own machine, work through
+> [`docs/production-hardening.md`](docs/production-hardening.md) first.
 
 ### Prerequisites
 1.  **Git:** Installed to clone the repository.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,10 @@ version: '3.8'
 
 services:
   # OHIF Viewer service (main viewer)
+  # ${BIND_HOST:-} prefix lets operators restrict every published port to
+  # localhost by setting BIND_HOST=127.0.0.1: (note trailing colon) in .env
+  # or the shell. Empty default preserves LAN-shared 0.0.0.0 binding.
+  # See docs/restrict-to-localhost.md.
   viewer:
     build:
       context: ../../
@@ -13,7 +17,7 @@ services:
       - ./config/app-config.js:/usr/share/nginx/html/app-config.js
  #     - ./logs/nginx:/var/log/nginx
     ports:
-      - '8081:8081'
+      - '${BIND_HOST:-}8081:8081'
     depends_on:
       - orthanc-viewer
       - keycloak
@@ -37,6 +41,7 @@ services:
       - ./orthanc/viewer/router.py:/python/router.py:ro
       - ./orthanc/viewer/feedback_routes.py:/python/feedback_routes.py:ro
       - ./orthanc/viewer/feedback_db.py:/python/feedback_db.py:ro
+      - ./orthanc/viewer/host_allowlist.py:/python/host_allowlist.py:ro
       - ./orthanc/viewer/ups:/python/ups:ro
       - ./volumes/orthanc-viewer-db/:/var/lib/orthanc/db/
       - ./volumes/feedback-db/:/var/lib/odelia-feedback/
@@ -46,8 +51,8 @@ services:
     networks:
       - odelia-network
     ports:
-      - '8000:8042' # HTTP port
-      - '2000:4242' # DICOM port
+      - '${BIND_HOST:-}8000:8042' # HTTP port
+      - '${BIND_HOST:-}2000:4242' # DICOM port
     environment:
       - ORTHANC__NAME=orthanc-viewer
       - VERBOSE_ENABLED=true
@@ -74,8 +79,8 @@ services:
     networks:
       - odelia-network
     ports:
-      - '4243:4242' # DICOM port (avoid conflict)
-      - '8043:8042' # HTTP port (avoid conflict)
+      - '${BIND_HOST:-}4243:4242' # DICOM port (avoid conflict)
+      - '${BIND_HOST:-}8043:8042' # HTTP port (avoid conflict)
     environment:
       - ORTHANC__NAME=orthanc-router-mst
       - VERBOSE_ENABLED=true
@@ -100,7 +105,7 @@ services:
     networks:
       - odelia-network
     ports:
-      - '5556:5556'
+      - '${BIND_HOST:-}5556:5556'
 
   # Orthanc Router service for MedGemma AI model
   orthanc-router-medgemma:
@@ -118,8 +123,8 @@ services:
     networks:
       - odelia-network
     ports:
-      - '4244:4242' # DICOM port (avoid conflict)
-      - '8044:8042' # HTTP port (avoid conflict)
+      - '${BIND_HOST:-}4244:4242' # DICOM port (avoid conflict)
+      - '${BIND_HOST:-}8044:8042' # HTTP port (avoid conflict)
     environment:
       - ORTHANC__NAME=orthanc-router-medgemma
       - VERBOSE_ENABLED=true
@@ -148,7 +153,7 @@ services:
     networks:
       - odelia-network
     ports:
-      - '5557:5557'
+      - '${BIND_HOST:-}5557:5557'
 #    deploy:
 #      resources:
 #        reservations:
@@ -177,7 +182,7 @@ services:
     networks:
       - odelia-network
     ports:
-      - '5560:5560'
+      - '${BIND_HOST:-}5560:5560'
     depends_on:
       - orthanc-viewer
     # Enable host.docker.internal on Linux
@@ -195,7 +200,7 @@ services:
     volumes:
       - ./volumes/models:/models:ro
     ports:
-      - '8090:8090'
+      - '${BIND_HOST:-}8090:8090'
     networks:
       - odelia-network
     restart: unless-stopped
@@ -225,7 +230,7 @@ services:
     image: grafana/grafana:11.1.0
     container_name: odelia-grafana
     ports:
-      - '3000:3000'
+      - '${BIND_HOST:-}3000:3000'
     user: "0:0"                          # run as root
     environment:
       - GF_INSTALL_PLUGINS=frser-sqlite-datasource
@@ -271,7 +276,7 @@ services:
       # added later
       PROXY_ADDRESS_FORWARDING: "true"
     ports:
-      - 8080:8080
+      - '${BIND_HOST:-}8080:8080'
     depends_on:
       - postgres
     restart: unless-stopped

--- a/docs/production-hardening.md
+++ b/docs/production-hardening.md
@@ -1,0 +1,180 @@
+# Production hardening checklist
+
+> **The default configuration of this repository is intended for local
+> research and demos.** It is optimized for `docker compose up` ease of
+> setup, not for production. If you intend to expose any part of this
+> stack beyond a trusted local network, work through this checklist
+> first — every default below is *insecure-by-design* for the sake of
+> the research UX.
+
+The threat model the defaults assume is:
+
+> "Keep easy local setup; prevent surprise production exposure. LAN
+> sharing with colleagues is a feature, not a bug."
+
+If your deployment violates that assumption (multi-tenant network, VPS,
+cloud VM, anything reachable from the public internet), do everything
+in the **Must-do** section. The **Should-do** section is recommended
+for any long-lived hosted deployment.
+
+---
+
+## Must-do before any non-local exposure
+
+### 1. Restrict published ports
+
+Default: every published port binds to `0.0.0.0`. Set `BIND_HOST=127.0.0.1:`
+(trailing colon required) in `.env` to flip the whole stack to loopback
+binding — see [`restrict-to-localhost.md`](restrict-to-localhost.md) for
+details. A managed firewall / security group is fine in addition, not as
+a replacement.
+
+### 2. Enable Orthanc authentication
+
+The Orthanc instances run with permissive auth defaults to make the
+demo painless. Before production:
+
+* Set `RegisteredUsers` in `orthanc/viewer/orthanc.json` (and the
+  router instances) with strong credentials.
+* Set `AuthenticationEnabled` to `true`.
+* Configure HTTPS in front of Orthanc (nginx, Traefik, Caddy).
+
+### 3. Rotate every default credential
+
+The repo ships with these *known-public* credentials so the stack
+starts out-of-the-box. **All of them must be changed.**
+
+| Service   | Default user | Default password | Source                                        |
+| --------- | ------------ | ---------------- | --------------------------------------------- |
+| Keycloak admin | `admin` | `admin`     | [`docker-compose.yml`](../docker-compose.yml) `KEYCLOAK_ADMIN_PASSWORD` |
+| Keycloak DB    | `keycloak` | `password` | [`docker-compose.yml`](../docker-compose.yml) `KC_DB_PASSWORD` |
+| Postgres       | `keycloak` | `password` | [`docker-compose.yml`](../docker-compose.yml) `POSTGRES_PASSWORD`      |
+| Grafana admin  | `admin` | `odelia`    | [`docker-compose.yml`](../docker-compose.yml) `GF_SECURITY_ADMIN_PASSWORD` |
+| Viewer login   | `viewer` | `viewer`   | Keycloak realm import [`config/ohif-keycloak-realm.json`](../config/ohif-keycloak-realm.json) |
+
+The preferred approach is to switch the compose file from hardcoded
+values to `${VAR:-default}` form and supply real secrets via a `.env`
+file that is **not** committed:
+
+```yaml
+# docker-compose.yml
+environment:
+  KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
+  KC_DB_PASSWORD:          ${KC_DB_PASSWORD:-password}
+  POSTGRES_PASSWORD:       ${POSTGRES_PASSWORD:-password}
+  GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD:-odelia}
+```
+
+```bash
+# .env (gitignored)
+KEYCLOAK_ADMIN_PASSWORD=<long random>
+KC_DB_PASSWORD=<long random>
+POSTGRES_PASSWORD=<long random>
+GF_SECURITY_ADMIN_PASSWORD=<long random>
+```
+
+Also create new realm users in Keycloak and remove the default
+`viewer/viewer` test user.
+
+### 4. Switch Keycloak out of dev mode
+
+`docker-compose.yml` runs Keycloak with `command: 'start-dev --import-realm'`,
+which disables HTTPS enforcement and brute-force protection. For
+production, switch to `start` and configure:
+
+* HTTPS termination (either Keycloak-native via `KC_HTTPS_*` env vars,
+  or a TLS-terminating reverse proxy in front).
+* `KC_HOSTNAME_STRICT_HTTPS=true`.
+* Brute-force detection in the realm settings.
+* Remove `KC_HOSTNAME_DEBUG=true` from environment.
+* Re-issue realm signing keys (the import file ships a key the world
+  can read).
+
+### 5. Validate routing target URLs
+
+Set `ROUTER_HOST_ALLOWLIST` (comma-separated hostnames) in the
+environment of `orthanc-viewer` and the `orthanc-router-*` services.
+When non-empty, the router REST handlers will reject any `target_url`,
+`wado_rs_base`, or `subscriber_url` whose hostname is not in the
+allowlist — preventing SSRF against `keycloak`, `grafana`, or cloud
+metadata endpoints. Empty / unset preserves the current research
+behaviour.
+
+Example:
+
+```yaml
+environment:
+  ROUTER_HOST_ALLOWLIST: "orthanc-viewer,orthanc-router-mst,orthanc-router-medgemma"
+```
+
+### 6. Disable debug API on chat-middleware
+
+The chat-middleware ships a debug router at `/debug` that exposes
+runtime configuration and cache inspection. Set
+`DEBUG_API_ENABLED=false` (or simply leave it unset and gate the
+blueprint registration on the env var) in any non-local profile.
+
+```yaml
+chat-middleware:
+  environment:
+    DEBUG_API_ENABLED: "false"
+```
+
+### 7. Tighten CORS
+
+`orthanc/MLIntegration/chat-middleware/app.py` allows `*` for
+`allow_origins`. Replace with an explicit list of the OHIF viewer
+origin(s) the chat-middleware should serve:
+
+```python
+allow_origins=[os.environ.get("CHAT_CORS_ORIGIN", "https://viewer.example.org")],
+```
+
+The Flask AI services (breast-cancer-classification, MST-classification,
+medgemma-mri) use `flask_cors.CORS(app)` with no whitelist; lock these
+down the same way if they will be reachable from a browser.
+
+---
+
+## Should-do for any hosted deployment
+
+### 8. Treat researcher-supplied `user_id` as untrusted
+
+The feedback endpoint accepts `user_id` straight from the request
+body. That is fine for low-friction annotation by trusted research
+users; in production, derive it from a validated Keycloak JWT
+(`Authorization: Bearer ...`) instead.
+
+### 9. Replace verbose error messages with correlation IDs
+
+Several Flask handlers return `str(e)` in JSON error responses. The
+exposure is low (exception messages, not stack traces) but a hosted
+deployment should swap to a generic error message and log the real
+exception against a correlation ID returned to the client.
+
+### 10. Bump container images on a schedule
+
+Some images are pinned to older versions for reproducible demos
+(notably `grafana/grafana:11.1.0` and
+`quay.io/keycloak/keycloak:24.0.5`). Long-lived hosted deployments
+should track upstream releases and rebuild periodically to pick up
+security fixes. Keep the pinned tag in the repo, but document the
+expected refresh cadence for your deployment.
+
+### 11. Remove TLS-verify bypass when wiring HTTPS
+
+`orthanc/MLIntegration/breast-cancer-classification/app.py` (legacy)
+calls Orthanc with `verify=False`. This is a no-op today because
+`ORTHANC_URL` is always plain HTTP inside the Docker network, but the
+flag is a latent footgun the moment anyone points the service at an
+HTTPS endpoint. Remove `verify=False` as part of the production pass.
+
+---
+
+## Where to look in the code
+
+* Compose file: [`docker-compose.yml`](../docker-compose.yml)
+* Orthanc viewer config: [`orthanc/viewer/orthanc.json`](../orthanc/viewer/orthanc.json)
+* Keycloak realm: [`config/ohif-keycloak-realm.json`](../config/ohif-keycloak-realm.json)
+* Router REST handlers: [`orthanc/viewer/router.py`](../orthanc/viewer/router.py), [`orthanc/router/ups/routes.py`](../orthanc/router/ups/routes.py), [`orthanc/router/ups/processor.py`](../orthanc/router/ups/processor.py)
+* Chat-middleware CORS / debug: [`orthanc/MLIntegration/chat-middleware/app.py`](../orthanc/MLIntegration/chat-middleware/app.py), [`orthanc/MLIntegration/chat-middleware/debug_routes.py`](../orthanc/MLIntegration/chat-middleware/debug_routes.py)

--- a/docs/production-hardening.md
+++ b/docs/production-hardening.md
@@ -138,21 +138,14 @@ down the same way if they will be reachable from a browser.
 
 ## Should-do for any hosted deployment
 
-### 8. Treat researcher-supplied `user_id` as untrusted
-
-The feedback endpoint accepts `user_id` straight from the request
-body. That is fine for low-friction annotation by trusted research
-users; in production, derive it from a validated Keycloak JWT
-(`Authorization: Bearer ...`) instead.
-
-### 9. Replace verbose error messages with correlation IDs
+### 8. Replace verbose error messages with correlation IDs
 
 Several Flask handlers return `str(e)` in JSON error responses. The
 exposure is low (exception messages, not stack traces) but a hosted
 deployment should swap to a generic error message and log the real
 exception against a correlation ID returned to the client.
 
-### 10. Bump container images on a schedule
+### 9. Bump container images on a schedule
 
 Some images are pinned to older versions for reproducible demos
 (notably `grafana/grafana:11.1.0` and
@@ -161,7 +154,7 @@ should track upstream releases and rebuild periodically to pick up
 security fixes. Keep the pinned tag in the repo, but document the
 expected refresh cadence for your deployment.
 
-### 11. Remove TLS-verify bypass when wiring HTTPS
+### 10. Remove TLS-verify bypass when wiring HTTPS
 
 `orthanc/MLIntegration/breast-cancer-classification/app.py` (legacy)
 calls Orthanc with `verify=False`. This is a no-op today because

--- a/docs/restrict-to-localhost.md
+++ b/docs/restrict-to-localhost.md
@@ -1,0 +1,78 @@
+# Restricting published ports to localhost
+
+By design, every published port in `docker-compose.yml` binds to `0.0.0.0`
+so colleagues on the same LAN can reach Orthanc / OHIF / chat-middleware /
+Grafana for joint research. **That is the desired default.**
+
+If you are running on a multi-tenant network, a VPS, or a cloud VM and you
+do *not* want LAN exposure, set the `BIND_HOST` environment variable to
+restrict every published port to `127.0.0.1` (loopback only).
+
+## Usage
+
+In `.env` (preferred — gitignored, so it does not leak into commits):
+
+```bash
+BIND_HOST=127.0.0.1:
+```
+
+…or as a one-shot shell override:
+
+```bash
+BIND_HOST=127.0.0.1: docker compose up -d
+```
+
+**The trailing colon is required** — each port mapping is interpolated as
+`${BIND_HOST:-}<host_port>:<container_port>`, so:
+
+* `BIND_HOST` unset / empty → `8081:8081` (current LAN-shared default)
+* `BIND_HOST=127.0.0.1:`    → `127.0.0.1:8081:8081` (loopback only)
+
+Verify with `docker compose config` — every published port should show
+`host_ip: 127.0.0.1` when `BIND_HOST` is set.
+
+## How it works
+
+Every port mapping in [`docker-compose.yml`](../docker-compose.yml) is
+written as:
+
+```yaml
+ports:
+  - '${BIND_HOST:-}8081:8081'
+```
+
+Docker Compose runs variable interpolation on port strings, so this
+single env var flips every published port in the stack at once. No
+override files, no parallel definitions to drift.
+
+## Affected ports
+
+| Service                     | Default       | With `BIND_HOST=127.0.0.1:` |
+| --------------------------- | ------------- | --------------------------- |
+| `viewer` (OHIF)             | `8081`        | `127.0.0.1:8081`            |
+| `orthanc-viewer` HTTP       | `8000`        | `127.0.0.1:8000`            |
+| `orthanc-viewer` DICOM      | `2000`        | `127.0.0.1:2000`            |
+| `orthanc-router-mst` DICOM  | `4243`        | `127.0.0.1:4243`            |
+| `orthanc-router-mst` HTTP   | `8043`        | `127.0.0.1:8043`            |
+| `mst-classifier`            | `5556`        | `127.0.0.1:5556`            |
+| `orthanc-router-medgemma` DICOM | `4244`    | `127.0.0.1:4244`            |
+| `orthanc-router-medgemma` HTTP  | `8044`    | `127.0.0.1:8044`            |
+| `medgemma-mri`              | `5557`        | `127.0.0.1:5557`            |
+| `chat-middleware`           | `5560`        | `127.0.0.1:5560`            |
+| `llamacpp-server` (profile) | `8090`        | `127.0.0.1:8090`            |
+| `grafana`                   | `3000`        | `127.0.0.1:3000`            |
+| `keycloak`                  | `8080`        | `127.0.0.1:8080`            |
+
+## When NOT to use this
+
+- You want a colleague at the next desk (same LAN / VPN) to open the OHIF
+  viewer at `http://<your-ip>:8081`. `BIND_HOST=127.0.0.1:` blocks that —
+  leave it unset.
+- You are running in a cloud VM but already using a managed firewall /
+  security group. `BIND_HOST` is belt-and-braces, not a replacement; both
+  layers are fine to stack.
+
+## Related hardening
+
+For production hardening beyond just port exposure (passwords, auth,
+HTTPS, CORS), see [`production-hardening.md`](production-hardening.md).

--- a/orthanc/MLIntegration/MST-classification/app_refactored.py
+++ b/orthanc/MLIntegration/MST-classification/app_refactored.py
@@ -9,6 +9,7 @@ from flask import Flask, request, jsonify
 from flask_cors import CORS
 
 from shared.config import StorageConfig
+from shared.security_banner import print_security_banner
 from config import MSTConfig
 from model_service import MSTModelService
 from exceptions import ModelNotLoadedError, InferenceError
@@ -103,6 +104,8 @@ def analyze_mri():
 
 
 if __name__ == "__main__":
+    print_security_banner("mst-classifier")
+
     # Initialize service before starting server
     initialize_service()
 

--- a/orthanc/MLIntegration/breast-cancer-classification/app_refactored.py
+++ b/orthanc/MLIntegration/breast-cancer-classification/app_refactored.py
@@ -9,6 +9,7 @@ from flask import Flask, request, jsonify
 from flask_cors import CORS
 
 from shared.config import StorageConfig
+from shared.security_banner import print_security_banner
 from config import BreastCancerConfig
 from model_service import BreastCancerModelService
 from exceptions import ModelNotLoadedError, InferenceError
@@ -105,6 +106,8 @@ def analyze_mri():
 
 
 if __name__ == "__main__":
+    print_security_banner("breast-cancer-classification")
+
     # Initialize service before starting server
     initialize_service()
 

--- a/orthanc/MLIntegration/chat-middleware/app.py
+++ b/orthanc/MLIntegration/chat-middleware/app.py
@@ -24,6 +24,7 @@ from image_cache import get_image_cache
 from ollama_client import get_ollama_client
 from websocket_handler import handle_websocket
 from debug_routes import router as debug_router
+from shared.security_banner import print_security_banner
 
 
 @asynccontextmanager
@@ -32,6 +33,7 @@ async def lifespan(app: FastAPI):
     Application lifespan handler for startup and shutdown events.
     """
     # Startup
+    print_security_banner("chat-middleware")
     logger.info("=" * 60)
     logger.info("Chat Middleware Service - Starting")
     logger.info("=" * 60)

--- a/orthanc/MLIntegration/medgemma-mri/app_refactored.py
+++ b/orthanc/MLIntegration/medgemma-mri/app_refactored.py
@@ -9,6 +9,7 @@ from flask import Flask, request, jsonify
 from flask_cors import CORS
 
 from shared.config import StorageConfig
+from shared.security_banner import print_security_banner
 from config import MedGemmaConfig
 from model_service import MedGemmaModelService
 from exceptions import ModelNotLoadedError, ModelAuthenticationError, InferenceError, ResponseParsingError
@@ -125,6 +126,8 @@ def analyze_mri():
 
 
 if __name__ == "__main__":
+    print_security_banner("medgemma-mri")
+
     # Initialize service before starting server
     initialize_service()
 

--- a/orthanc/MLIntegration/shared/__init__.py
+++ b/orthanc/MLIntegration/shared/__init__.py
@@ -4,8 +4,12 @@ Shared utilities for ML Integration services
 
 from .exceptions import DicomRetrievalError
 from .config import StorageConfig
+from .dicom_storage import validate_series_uid
+from .security_banner import print_security_banner
 
 __all__ = [
     'DicomRetrievalError',
     'StorageConfig',
+    'validate_series_uid',
+    'print_security_banner',
 ]

--- a/orthanc/MLIntegration/shared/dicom_storage.py
+++ b/orthanc/MLIntegration/shared/dicom_storage.py
@@ -3,6 +3,7 @@ DICOM file storage utilities
 Single Responsibility: File system operations for DICOM data
 """
 import os
+import re
 import shutil
 import logging
 from pathlib import Path
@@ -12,6 +13,29 @@ from pydicom.dataset import Dataset
 from .config import StorageConfig
 
 logger = logging.getLogger(__name__)
+
+
+# DICOM PS3.5 §9.1: a UID is a sequence of non-empty numeric components
+# separated by '.', max 64 chars total. Anchored fullmatch — blocks path
+# traversal ('..', '/etc', 'foo/../bar') and any other attacker-controlled
+# filename smuggled in via series_uid.
+_SERIES_UID_RE = re.compile(r"[0-9]+(?:\.[0-9]+)*")
+
+
+def validate_series_uid(series_uid: str) -> str:
+    """
+    Validate a DICOM SeriesInstanceUID before using it as a filesystem path
+    component. Returns the input on success; raises ValueError otherwise.
+
+    Blocks path-traversal payloads such as '..', '/etc', and 'foo/../bar'.
+    """
+    if (
+        not isinstance(series_uid, str)
+        or len(series_uid) > 64
+        or not _SERIES_UID_RE.fullmatch(series_uid)
+    ):
+        raise ValueError(f"invalid series_uid: {series_uid!r}")
+    return series_uid
 
 
 def create_series_folder(series_uid: str, storage_config: StorageConfig, clean: bool = True) -> Path:
@@ -26,6 +50,7 @@ def create_series_folder(series_uid: str, storage_config: StorageConfig, clean: 
     Returns:
         Path to created series folder
     """
+    validate_series_uid(series_uid)
     series_folder = Path(storage_config.image_folder) / series_uid
 
     # Clean up if exists and clean=True

--- a/orthanc/MLIntegration/shared/security_banner.py
+++ b/orthanc/MLIntegration/shared/security_banner.py
@@ -1,0 +1,45 @@
+"""
+Startup banner that warns operators when an AI service is running with
+research / demo defaults. Printed to stderr so it survives most logging
+configurations and is visible in `docker compose logs`.
+
+Suppress with `ODELIA_SUPPRESS_SECURITY_BANNER=1` once you have read
+docs/production-hardening.md and intentionally accept the posture.
+"""
+import os
+import sys
+
+
+_BANNER_LINES = [
+    "",
+    "=" * 72,
+    "WARNING — Odelia research / demo defaults are in effect.",
+    "",
+    "This service ships with insecure-by-design defaults intended for local",
+    "research and demos. Do NOT expose this stack to an untrusted network",
+    "without working through docs/production-hardening.md first.",
+    "",
+    "Known defaults that need changing for non-local deployments:",
+    "  * Published ports bind to 0.0.0.0 (LAN-shared)",
+    "  * Orthanc auth permissive; Keycloak in start-dev mode",
+    "  * Hardcoded admin passwords for Keycloak / Grafana / Postgres",
+    "  * CORS = '*' on chat-middleware; debug API on by default",
+    "  * Routing endpoints accept arbitrary hostnames unless",
+    "    ROUTER_HOST_ALLOWLIST is set",
+    "",
+    "See docs/production-hardening.md.",
+    "Suppress this banner with ODELIA_SUPPRESS_SECURITY_BANNER=1.",
+    "=" * 72,
+    "",
+]
+
+
+def print_security_banner(service_name: str = "") -> None:
+    """Print the research-defaults warning banner to stderr, once."""
+    if os.environ.get("ODELIA_SUPPRESS_SECURITY_BANNER") == "1":
+        return
+    if service_name:
+        sys.stderr.write(f"[{service_name}] ")
+    for line in _BANNER_LINES:
+        sys.stderr.write(line + "\n")
+    sys.stderr.flush()

--- a/orthanc/MLIntegration/shared/tests/test_dicom_storage.py
+++ b/orthanc/MLIntegration/shared/tests/test_dicom_storage.py
@@ -1,0 +1,107 @@
+"""
+Unit tests for shared.dicom_storage.
+
+Covers the security-critical series_uid validator (ODV-190 M2) and the
+defence-in-depth behaviour of create_series_folder.
+"""
+from pathlib import Path
+
+import pytest
+
+from shared.dicom_storage import (
+    create_series_folder,
+    validate_series_uid,
+)
+from shared.config import StorageConfig
+
+
+# ---------------------------------------------------------------------------
+# validate_series_uid
+# ---------------------------------------------------------------------------
+
+class TestValidateSeriesUid:
+    """Strict DICOM-UID allowlist: digits and dots only, 1..64 chars."""
+
+    def test_accepts_legitimate_dicom_uid(self):
+        uid = "1.2.826.0.1.3680043.2.1125.123456789"
+        assert validate_series_uid(uid) == uid
+
+    def test_accepts_short_uid(self):
+        assert validate_series_uid("1") == "1"
+
+    def test_accepts_max_length_uid(self):
+        uid = "1." + "2" * 62
+        assert len(uid) == 64
+        assert validate_series_uid(uid) == uid
+
+    def test_rejects_parent_directory_traversal(self):
+        with pytest.raises(ValueError, match="invalid series_uid"):
+            validate_series_uid("..")
+
+    def test_rejects_relative_traversal(self):
+        with pytest.raises(ValueError, match="invalid series_uid"):
+            validate_series_uid("../../etc")
+
+    def test_rejects_absolute_path(self):
+        with pytest.raises(ValueError, match="invalid series_uid"):
+            validate_series_uid("/etc")
+
+    def test_rejects_path_separator(self):
+        with pytest.raises(ValueError, match="invalid series_uid"):
+            validate_series_uid("1.2.3/4.5.6")
+
+    def test_rejects_backslash(self):
+        with pytest.raises(ValueError, match="invalid series_uid"):
+            validate_series_uid("1.2.3\\4")
+
+    def test_rejects_letters(self):
+        with pytest.raises(ValueError, match="invalid series_uid"):
+            validate_series_uid("1.2.abc")
+
+    def test_rejects_null_byte(self):
+        with pytest.raises(ValueError, match="invalid series_uid"):
+            validate_series_uid("1.2\x00.3")
+
+    def test_rejects_too_long(self):
+        with pytest.raises(ValueError, match="invalid series_uid"):
+            validate_series_uid("1" * 65)
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(ValueError, match="invalid series_uid"):
+            validate_series_uid("")
+
+    def test_rejects_non_string(self):
+        with pytest.raises(ValueError, match="invalid series_uid"):
+            validate_series_uid(None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# create_series_folder
+# ---------------------------------------------------------------------------
+
+class TestCreateSeriesFolder:
+    """create_series_folder must refuse to touch the filesystem on bad input."""
+
+    def test_creates_folder_for_legitimate_uid(self, tmp_path: Path):
+        uid = "1.2.826.0.1.3680043.2.1125.42"
+        cfg = StorageConfig(image_folder=tmp_path, cleanup_on_start=False)
+
+        folder = create_series_folder(uid, cfg)
+
+        assert folder == tmp_path / uid
+        assert folder.exists()
+        assert folder.is_dir()
+
+    def test_rejects_traversal_without_touching_filesystem(self, tmp_path: Path):
+        cfg = StorageConfig(image_folder=tmp_path, cleanup_on_start=False)
+        # Put a sentinel directory next to image_folder; a successful traversal
+        # would target it. The validator must fire before any FS op.
+        sibling = tmp_path.parent / "would-be-deleted"
+        sibling.mkdir()
+        (sibling / "keep.txt").write_text("untouched")
+
+        with pytest.raises(ValueError, match="invalid series_uid"):
+            create_series_folder("../would-be-deleted", cfg)
+
+        assert sibling.exists()
+        assert (sibling / "keep.txt").read_text() == "untouched"

--- a/orthanc/router/host_allowlist.py
+++ b/orthanc/router/host_allowlist.py
@@ -1,0 +1,52 @@
+"""
+Optional hostname allowlist for outbound URLs in UPS routing endpoints.
+
+Reads `ROUTER_HOST_ALLOWLIST` (comma-separated) from the environment.
+Empty / unset => no enforcement (current research behaviour).
+Non-empty   => URLs whose hostname is not in the set are rejected.
+
+See docs/production-hardening.md.
+"""
+import os
+from urllib.parse import urlparse
+
+
+def _load_allowlist():
+    raw = os.environ.get("ROUTER_HOST_ALLOWLIST", "").strip()
+    if not raw:
+        return None
+    return {h.strip().lower() for h in raw.split(",") if h.strip()}
+
+
+def _extract_host(url: str) -> str:
+    """
+    Extract a hostname from either:
+      * a proper URL ("http://orthanc-router-mst:8042/dicom-web") — via urlparse
+      * a DICOM modality target ("orthanc-router-mst:4242/AET") — by splitting
+        on ':' / '/' (urlparse treats the first token as the scheme here)
+    Returns "" if no host can be identified.
+    """
+    if not url:
+        return ""
+    try:
+        host = urlparse(url).hostname or ""
+    except Exception:
+        host = ""
+    if host:
+        return host.lower()
+    token = url.split("://", 1)[-1]
+    token = token.split("/", 1)[0]
+    token = token.split(":", 1)[0]
+    return token.lower()
+
+
+def host_is_allowed(url: str) -> bool:
+    """
+    Return True if `url`'s hostname is allowed (or the allowlist is empty /
+    unset). Returns False for unparseable URLs or hosts not in the allowlist.
+    """
+    allow = _load_allowlist()
+    if allow is None:
+        return True
+    host = _extract_host(url)
+    return bool(host) and host in allow

--- a/orthanc/router/ups/processor.py
+++ b/orthanc/router/ups/processor.py
@@ -16,6 +16,14 @@ from pydicom.uid import generate_uid
 from ups.storage import ups_storage
 from wado_utils import retrieve_series_metadata_sorted
 
+# Optional outbound-host allowlist (ROUTER_HOST_ALLOWLIST env var). Empty /
+# unset preserves current research behaviour. See docs/production-hardening.md.
+try:
+    from host_allowlist import host_is_allowed  # type: ignore
+except Exception:
+    def host_is_allowed(_url: str) -> bool:
+        return True
+
 
 # Get MODEL_BACKEND_URL from environment (configured per router instance in docker-compose)
 MODEL_BACKEND_URL = os.environ.get("MODEL_BACKEND_URL", "http://breast-cancer-classification:5555")
@@ -32,6 +40,12 @@ def notify_subscriber(workitem, subscriber_url):
         workitem: UPSWorkitem instance
         subscriber_url: Subscriber's callback URL
     """
+    if not host_is_allowed(subscriber_url):
+        # Defense in depth: subscriber URLs are also validated at intake
+        # (SubscribeToWorkitem), but check again on egress in case the
+        # subscription store was populated by some other path.
+        print(f"notify_subscriber: subscriber_url host not in ROUTER_HOST_ALLOWLIST, skipping: {subscriber_url}")
+        return
     try:
         response = requests.post(
             f"{subscriber_url}/ups-rs/workitems/{workitem.workitem_uid}",

--- a/orthanc/router/ups/routes.py
+++ b/orthanc/router/ups/routes.py
@@ -12,6 +12,15 @@ from ups.workitem import UPSWorkitem
 from ups.storage import ups_storage
 from ups.processor import process_workitem
 
+# Optional outbound-host allowlist (ROUTER_HOST_ALLOWLIST env var). When
+# unset/empty, host_is_allowed() returns True — preserves current research
+# behaviour. See docs/production-hardening.md.
+try:
+    from host_allowlist import host_is_allowed  # type: ignore
+except Exception:
+    def host_is_allowed(_url: str) -> bool:
+        return True
+
 MANIFEST_PATH = os.environ.get("AI_MANIFEST_PATH", "/etc/orthanc/manifest.json")
 
 
@@ -47,6 +56,11 @@ def CreateWorkitem(output, uri, **request):
 
         if not study_uid:
             output.SendHttpStatus(400, "Missing study_uid in request body")
+            return
+
+        if not host_is_allowed(wado_rs_base):
+            print(f"CreateWorkitem: wado_rs_base host not in ROUTER_HOST_ALLOWLIST: {wado_rs_base}")
+            output.SendHttpStatus(403, "wado_rs_base host not allowed")
             return
 
         # Build WADO-RS retrieval URLs
@@ -278,6 +292,11 @@ def SubscribeToWorkitem(output, uri, **request):
 
         if not subscriber_url:
             output.SendHttpStatus(400, "Missing subscriber_url in request body")
+            return
+
+        if not host_is_allowed(subscriber_url):
+            print(f"SubscribeToWorkitem: subscriber_url host not in ROUTER_HOST_ALLOWLIST: {subscriber_url}")
+            output.SendHttpStatus(403, "subscriber_url host not allowed")
             return
 
         # Verify workitem exists

--- a/orthanc/viewer/host_allowlist.py
+++ b/orthanc/viewer/host_allowlist.py
@@ -1,0 +1,52 @@
+"""
+Optional hostname allowlist for outbound URLs in routing endpoints.
+
+Reads `ROUTER_HOST_ALLOWLIST` (comma-separated) from the environment.
+Empty / unset => no enforcement (current research behaviour).
+Non-empty   => URLs whose hostname is not in the set are rejected.
+
+See docs/production-hardening.md.
+"""
+import os
+from urllib.parse import urlparse
+
+
+def _load_allowlist():
+    raw = os.environ.get("ROUTER_HOST_ALLOWLIST", "").strip()
+    if not raw:
+        return None
+    return {h.strip().lower() for h in raw.split(",") if h.strip()}
+
+
+def _extract_host(url: str) -> str:
+    """
+    Extract a hostname from either:
+      * a proper URL ("http://orthanc-router-mst:8042/dicom-web") — via urlparse
+      * a DICOM modality target ("orthanc-router-mst:4242/AET") — by splitting
+        on ':' / '/' (urlparse treats the first token as the scheme here)
+    Returns "" if no host can be identified.
+    """
+    if not url:
+        return ""
+    try:
+        host = urlparse(url).hostname or ""
+    except Exception:
+        host = ""
+    if host:
+        return host.lower()
+    token = url.split("://", 1)[-1]
+    token = token.split("/", 1)[0]
+    token = token.split(":", 1)[0]
+    return token.lower()
+
+
+def host_is_allowed(url: str) -> bool:
+    """
+    Return True if `url`'s hostname is allowed (or the allowlist is empty /
+    unset). Returns False for unparseable URLs or hosts not in the allowlist.
+    """
+    allow = _load_allowlist()
+    if allow is None:
+        return True
+    host = _extract_host(url)
+    return bool(host) and host in allow

--- a/orthanc/viewer/router.py
+++ b/orthanc/viewer/router.py
@@ -21,6 +21,15 @@ try:
 except Exception:
     register_feedback_endpoints = None
 
+# Optional outbound-host allowlist (ROUTER_HOST_ALLOWLIST env var).
+# When unset/empty, host_is_allowed() returns True for any input — preserves
+# the current research behaviour. See docs/production-hardening.md.
+try:
+    from host_allowlist import host_is_allowed  # type: ignore
+except Exception:
+    def host_is_allowed(_url: str) -> bool:  # fallback: allow all
+        return True
+
 # UPS storage for workitem persistence
 try:
     from ups.storage import UPSStorage
@@ -156,6 +165,11 @@ def SendToAiDicom(output, uri, **request):
 
         if not study_id or not target:
             output.SendHttpStatus(400, "Missing study_id or target in request body")
+            return
+
+        if target_url and not host_is_allowed(target_url):
+            print(f"SendToAiDicom: target_url host not in ROUTER_HOST_ALLOWLIST: {target_url}")
+            output.SendHttpStatus(403, "target_url host not allowed")
             return
 
         # If series_uids not provided, check if study has processable content
@@ -376,6 +390,11 @@ def SendToAiDicomWeb(output, uri, **request):
         if not target_url:
             print("SendToAiDicomWeb: Missing target_url parameter")
             output.SendHttpStatus(400, "Missing target_url in request body")
+            return
+
+        if not host_is_allowed(target_url):
+            print(f"SendToAiDicomWeb: target_url host not in ROUTER_HOST_ALLOWLIST: {target_url}")
+            output.SendHttpStatus(403, "target_url host not allowed")
             return
 
         # Verify study_id exists in Orthanc
@@ -714,6 +733,11 @@ def GetAIManifest(output, uri, **request):
 
         if not target_url:
             output.SendHttpStatus(400, "Missing target_url query parameter")
+            return
+
+        if not host_is_allowed(target_url):
+            print(f"GetAIManifest: target_url host not in ROUTER_HOST_ALLOWLIST: {target_url}")
+            output.SendHttpStatus(403, "target_url host not allowed")
             return
 
         router_base_url = target_url.replace("/dicom-web", "").rstrip("/")


### PR DESCRIPTION
## Summary

Implements [ODV-190](https://stratifai.atlassian.net/browse/ODV-190) — security hardening for the research/demo posture. Adds the one genuine bug fix (path traversal via `series_uid`) and three opt-in production-hardening toggles that all preserve the current local-research UX when unset.

> **Threat model:** "Keep easy local setup; prevent surprise production exposure. LAN sharing with colleagues is a feature, not a bug." Defaults are unchanged — every new control is off by default.

## Changes

### M1 — `BIND_HOST` env var for localhost-only binding
- Every published port in [`docker-compose.yml`](docker-compose.yml) now reads `'${BIND_HOST:-}<host>:<container>'`.
- Default (unset) → `8081:8081` (LAN-shared, unchanged).
- Set `BIND_HOST=127.0.0.1:` (trailing colon required) in `.env` → every port rebinds to loopback.
- Verified with `docker compose config`: all 13 published ports flip to `host_ip: 127.0.0.1` when set.
- New doc: [`docs/restrict-to-localhost.md`](docs/restrict-to-localhost.md).

### M2 — `series_uid` path-traversal fix (the only real bug)
- New `validate_series_uid()` in [`orthanc/MLIntegration/shared/dicom_storage.py`](orthanc/MLIntegration/shared/dicom_storage.py) — strict DICOM-UID regex (`[0-9]+(\.[0-9]+)*`, ≤64 chars).
- Applied at `create_series_folder()`, so all retrieval paths (MST, breast-cancer, medgemma, chat-middleware) are covered through a single chokepoint.
- Blocks `..`, `/etc`, `foo/../bar`, null bytes, oversize input, and non-string types before any `shutil.rmtree` / `open(..., "wb")` call.
- Unit tests in [`orthanc/MLIntegration/shared/tests/test_dicom_storage.py`](orthanc/MLIntegration/shared/tests/test_dicom_storage.py) covering legitimate UIDs and traversal payloads, plus an end-to-end check that a malicious UID does not touch a sibling directory.

### M3 — Production-hardening doc + startup warnings
- New [`docs/production-hardening.md`](docs/production-hardening.md): checklist covering port exposure, Orthanc auth, credential rotation, Keycloak `start` mode, SSRF allowlist, debug API, CORS, and the minor points m1–m7 from the ticket.
- README warning moved into the *Installation and Setup* section (not the top — reader still sees the project overview first) pointing to the hardening doc.
- New `shared/security_banner.py` prints a stderr banner from all four AI services on startup (`mst-classifier`, `breast-cancer-classification`, `medgemma-mri`, `chat-middleware`).
- Suppressible with `ODELIA_SUPPRESS_SECURITY_BANNER=1` once operators have acknowledged the posture.

### M4 — `ROUTER_HOST_ALLOWLIST` for SSRF protection
- New `host_allowlist.py` helper (one copy per container — viewer and router each get their own, since they ship in separate images).
- Handles both URL formats: proper URLs (`http://orthanc-viewer:8042/...`) and DICOM-modality style (`host:port/AET`).
- Enforced at five entry points:
  - [`orthanc/viewer/router.py`](orthanc/viewer/router.py): `SendToAiDicom`, `SendToAiDicomWeb`, `GetAIManifest`
  - [`orthanc/router/ups/routes.py`](orthanc/router/ups/routes.py): `CreateWorkitem` (`wado_rs_base`), `SubscribeToWorkitem` (`subscriber_url`)
- Defense in depth at [`orthanc/router/ups/processor.py`](orthanc/router/ups/processor.py) `notify_subscriber` — re-checks the subscriber URL on egress.
- Empty/unset env var = current research behaviour. Set e.g. `ROUTER_HOST_ALLOWLIST=orthanc-viewer,orthanc-router-mst,orthanc-router-medgemma` to enforce.

### Minor points (m1–m7)
Documented in `production-hardening.md` rather than enforced — credential rotation pattern, debug API gating, untrusted `user_id` contract, CORS tightening, image pin policy, TLS-verify cleanup, error-message sanitisation. No code changes; these are operator-facing.

## Acceptance criteria (from the ticket)

- [x] **M1** — `docs/restrict-to-localhost.md` merged with a working mechanism; default in `docker-compose.yml` remains `0.0.0.0` (LAN-shared). *(Chose env-var interpolation over a parallel override file — single source of truth, no drift.)*
- [x] **M2** — `series_uid` validator added to `shared/dicom_storage.py`; unit tests cover `..`, `/etc`, and a legitimate DICOM UID. All retrieval services use the shared helper, so no inline duplicates remain.
- [x] **M3** — README warning (in the setup section, not the masthead) + `docs/production-hardening.md` merged; startup banner from all four Flask/FastAPI AI services.
- [x] **M4** — `ROUTER_HOST_ALLOWLIST` env var honoured in all four routing handlers (plus `SubscribeToWorkitem` and `notify_subscriber`); empty = current behaviour.
- [x] **m1–m7** — documented in the hardening doc.

## Test plan

- [ ] `docker compose up -d` works unchanged with no env vars set (default research posture preserved).
- [ ] `BIND_HOST=127.0.0.1: docker compose up -d` — confirm OHIF/Orthanc reachable from `localhost` but not from `<lan-ip>`.
- [ ] `docker compose config` (default vs `BIND_HOST=127.0.0.1:`) — verify `host_ip` field appears only with the env var set.
- [ ] Send a malformed `series_uid` (`"../foo"`) to `/analyze/mri` on any AI service — should 400 with "invalid series_uid", no filesystem write.
- [ ] Set `ROUTER_HOST_ALLOWLIST=orthanc-viewer` and POST `SendToAiDicomWeb` with `target_url: http://attacker.example/dicom-web` — expect 403.
- [ ] Same config, POST with `target_url: http://orthanc-router-mst:8043/dicom-web` — expect normal flow.
- [ ] Run `pytest orthanc/MLIntegration/shared/tests/test_dicom_storage.py` from the MLIntegration root — all green.
- [ ] Start any AI service container and confirm the `WARNING — Odelia research / demo defaults` banner appears in `docker compose logs`.
- [ ] Set `ODELIA_SUPPRESS_SECURITY_BANNER=1` and confirm the banner is gone.

## Notes for reviewers

- Two copies of `host_allowlist.py` (one under `orthanc/viewer/`, one under `orthanc/router/`) are intentional — the viewer and router build into separate images, and the helper is ~20 lines. Factoring out a shared package would mean a third volume mount or a new pip-installable module for marginal benefit.
- The `M3` startup banner imports `shared.security_banner`, which is already shipped as part of the `mlintegration` package every AI service installs via `pip install -e .` — no Dockerfile changes needed.
- The original ticket suggested a parallel `docker-compose.localhost.override.yml` for M1. I went with single-file env interpolation instead — same outcome, no duplication. Doc reflects the chosen approach.
